### PR TITLE
Update composer.json to allow latest jsm serializer bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.3.3",
         "avoo/serializer-translation": "0.1.*",
-        "jms/serializer-bundle": "~0.13"
+        "jms/serializer-bundle": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
Can you update your bundle to allow latest jms/serializer-bundle? 

Maybe allow both 0.x and 1.x bundle or add a seperate release? 